### PR TITLE
Support Python generators

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -24,6 +24,8 @@ const languageVariantPairs = [
     "PHP,pecl_http",
     "PHP,HTTP_Request2",
     "PowerShell,RestMethod",
+    "Python,http.client",
+    "Python,Requests",
     "Ruby,Net:HTTP",
     "Shell,Httpie",
     "Shell,wget",


### PR DESCRIPTION
I have tested this locally and was able to convert my Postman collection with:
- `-l python,requests`
- `-l python,http.client`

Not sure how you generate the `main.js` from `main.ts`, so I only edited the `main.ts` in the pull request