### PR TITLE
Add --names and --short flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Options:
                                  override variables provided in collection
   -d, --debug                    Output additional debugging info
   --short                        Use short format for curl commands
-  --names                        Add request names as headers/comments in curl
-                                 commands output
+  --names                        Add request names as comments in curl commands
+                                 output
   -h, --help                     output usage information
 ```
 ### Generate cURL code

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Options:
                                  Postman. NOTE: Environment variables will not
                                  override variables provided in collection
   -d, --debug                    Output additional debugging info
-  --short                        Use short format for commands
-  --names                        Output request names with hashtag and newline
+  --short                        Use short format for curl commands
+  --names                        Add request names as headers/comments in curl
+                                 commands output
   -h, --help                     output usage information
 ```
 ### Generate cURL code

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ Usage: generate [options]
 Options:
   -V, --version                  output the version number
   -c, --collection <path>        Path to the Postman 2.1 Collection JSON
-  -l,--language_variant <tuple>  Language,Variant pair to output (default: "cURL,cURL")
-  -e,--envvars <path>            Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection
+  -l,--language_variant <tuple>  Language,Variant pair to output (default:
+                                 {"language":"curl","variant":"curl"})
+  -e,--envvars <path>            Path to environment variables exported from
+                                 Postman. NOTE: Environment variables will not
+                                 override variables provided in collection
   -d, --debug                    Output additional debugging info
+  --short                        Use short format for commands
+  --names                        Output request names with hashtag and newline
   -h, --help                     output usage information
 ```
 ### Generate cURL code
@@ -26,6 +31,9 @@ node main.js -c example_collection.json
 # curl --location --request GET 'https://v7rr12wbr7.execute-api.us-west-2.amazonaws.com/prod/courses?c0=PHYS153&c1=APSC160&c2=CHEM154&c3=MATH100&c4=APSC150&c5=MATH101&c6=MATH152&c7=PHYS170&c8=ENGL112&c9=MATH253&c10=MECH226&c11=MATH255&c12=MECH220&c13=MECH221&c14=MECH224&c15=MECH222&c16=MECH223&c17=MECH225&c18=MECH375&c19=MECH368&c20=MECH360&c21=MECH328&c22=MECH326&c23=MECH325&c24=CIVL200&c25=EOSC114&c26=PHIL120&c27=MECH380&c28=MECH358&c29=MECH305&c30=LING101&c31=MATH307&version_key=1.2'
 # curl --location --request GET 'https://v7rr12wbr7.execute-api.us-west-2.amazonaws.com/prod/courses?c0=PHYS153'
 ```
+
+**Note:** Use `--short` flag for shorthand arguments and `--names` for adding request name headers (comment)
+
 ### Generate other languages
 
 ```bash

--- a/main.js
+++ b/main.js
@@ -59,10 +59,11 @@ debugPrint(program.opts());
 var collectionPath = program["collection"];
 var collection = new postman_collection_1.Collection(JSON.parse((0, fs_1.readFileSync)(collectionPath).toString()));
 debugPrint(collection);
+var lvp = program["language_variant"];
 var options = {
     trimRequestBody: true,
     followRedirect: true,
-    longFormat: !program["short"],
+    longFormat: !(program["short"] && lvp.language === "curl" && lvp.variant === "curl"),
 };
 function isItem(itemG) {
     return itemG.request !== undefined;
@@ -82,11 +83,16 @@ function printSnippet(item) {
             if (matches && matches.length > 0) {
                 matches.forEach(function (m) { return console.warn("".concat(m, " : Variable not provided")); });
             }
-            // add request name as header if --names is set
-            if (program["names"]) {
-                console.log("# ".concat(item.name));
-                console.log(completeSnippet);
-                console.log();
+            // output request names as comments for curl if --names flag is set
+            if (lvp.language === "curl" && lvp.variant === "curl") {
+                if (program["names"]) {
+                    console.log("# ".concat(item.name));
+                    console.log(completeSnippet);
+                    console.log();
+                }
+                else {
+                    console.log(completeSnippet);
+                }
             }
             else {
                 console.log(completeSnippet);
@@ -105,6 +111,5 @@ if (program["envvars"]) {
         environmentVariables.append(new postman_collection_1.Variable(v));
     });
 }
-var lvp = program["language_variant"];
 debugPrint(environmentVariables);
 collection.items.all().forEach(printSnippet);

--- a/main.js
+++ b/main.js
@@ -47,8 +47,8 @@ program
     .option("-l,--language_variant <tuple>", "Language,Variant pair to output", parseTuple, { language: "curl", variant: "curl" })
     .option("-e,--envvars <path>", "Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection")
     .option("-d, --debug", "Output additional debugging info")
-    .option("--short", "Use short format for commands")
-    .option("--names", "Output request names with hashtag and newline");
+    .option("--short", "Use short format for curl commands")
+    .option("--names", "Add request names as headers/comments in curl commands output");
 program.parse(process.argv);
 function debugPrint(message) {
     if (program.debug) {

--- a/main.js
+++ b/main.js
@@ -1,65 +1,68 @@
 "use strict";
-exports.__esModule = true;
+Object.defineProperty(exports, "__esModule", { value: true });
 var postman_collection_1 = require("postman-collection");
-var codegen = require('postman-code-generators');
+var codegen = require("postman-code-generators");
 var fs_1 = require("fs");
 var commander = require("commander");
 var languageVariantPairs = [
-    'C#,RestSharp',
-    'Dart,http',
-    'cURL,cURL',
-    'Go,Native',
-    'HTTP,HTTP',
-    'Java,OkHttp',
-    'Java,Unirest',
-    'JavaScript,Fetch',
-    'JavaScript,jQuery',
-    'JavaScript,XHR',
-    'NodeJs,Native',
-    'NodeJs,Request',
-    'NodeJs,Unirest',
-    'Objective-C,NSURLSession',
-    'OCaml,Cohttp',
-    'PHP,cURL',
-    'PHP,pecl_http',
-    'PHP,HTTP_Request2',
-    'PowerShell,RestMethod',
-    'Python,http.client',
-    'Python,Requests',
-    'Ruby,Net:HTTP',
-    'Shell,Httpie',
-    'Shell,wget',
-    'Swift,URLSession'
+    "C#,RestSharp",
+    "Dart,http",
+    "cURL,cURL",
+    "Go,Native",
+    "HTTP,HTTP",
+    "Java,OkHttp",
+    "Java,Unirest",
+    "JavaScript,Fetch",
+    "JavaScript,jQuery",
+    "JavaScript,XHR",
+    "NodeJs,Native",
+    "NodeJs,Request",
+    "NodeJs,Unirest",
+    "Objective-C,NSURLSession",
+    "OCaml,Cohttp",
+    "PHP,cURL",
+    "PHP,pecl_http",
+    "PHP,HTTP_Request2",
+    "PowerShell,RestMethod",
+    "Python,http.client",
+    "Python,Requests",
+    "Ruby,Net:HTTP",
+    "Shell,Httpie",
+    "Shell,wget",
+    "Swift,URLSession",
 ].map(function (v) { return v.toLowerCase(); });
 function parseTuple(value, dummy) {
     var v = value.trim().toLowerCase();
     if (!languageVariantPairs.includes(v)) {
-        throw "Not a valid <langauge,variant> pair.Try one of:\n" + languageVariantPairs.join('\n') + "\n";
+        throw "Not a valid <langauge,variant> pair.Try one of:\n".concat(languageVariantPairs.join("\n"), "\n");
     }
-    var tuple = v.split(',');
+    var tuple = v.split(",");
     console.assert(tuple.length === 2);
     return { language: tuple[0], variant: tuple[1] };
 }
-var program = new commander.Command('generate');
-program.version('0.2');
+var program = new commander.Command("generate");
+program.version("0.2");
 program
-    .requiredOption('-c, --collection <path>', 'Path to the Postman 2.1 Collection JSON')
-    .option('-l,--language_variant <tuple>', 'Language,Variant pair to output', parseTuple, { language: 'curl', variant: 'curl' })
-    .option('-e,--envvars <path>', "Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection")
-    .option('-d, --debug', 'Output additional debugging info');
+    .requiredOption("-c, --collection <path>", "Path to the Postman 2.1 Collection JSON")
+    .option("-l,--language_variant <tuple>", "Language,Variant pair to output", parseTuple, { language: "curl", variant: "curl" })
+    .option("-e,--envvars <path>", "Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection")
+    .option("-d, --debug", "Output additional debugging info")
+    .option("--short", "Use short format for commands")
+    .option("--names", "Output request names with hashtag and newline");
 program.parse(process.argv);
 function debugPrint(message) {
     if (program.debug) {
-        console.log('DEBUG:', message);
+        console.log("DEBUG:", message);
     }
 }
 debugPrint(program.opts());
-var collectionPath = program['collection'];
+var collectionPath = program["collection"];
 var collection = new postman_collection_1.Collection(JSON.parse((0, fs_1.readFileSync)(collectionPath).toString()));
 debugPrint(collection);
 var options = {
     trimRequestBody: true,
-    followRedirect: true
+    followRedirect: true,
+    longFormat: !program["short"],
 };
 function isItem(itemG) {
     return itemG.request !== undefined;
@@ -71,29 +74,37 @@ function printSnippet(item) {
     if (isItem(item)) {
         codegen.convert(lvp.language, lvp.variant, item.request, options, function (error, snippet) {
             if (error) {
-                console.error('Error trying to generate code for request:', item.request, error);
+                console.error("Error trying to generate code for request:", item.request, error);
             }
             var completeSnippet = collection.variables.replace(snippet, environmentVariables);
             var re = /(?:\{\{(.+?)\}\})/g;
             var matches = re.exec(completeSnippet);
             if (matches && matches.length > 0) {
-                matches.forEach(function (m) { return console.warn(m + " : Variable not provided"); });
+                matches.forEach(function (m) { return console.warn("".concat(m, " : Variable not provided")); });
             }
-            console.log(completeSnippet);
+            // add request name as header if --names is set
+            if (program["names"]) {
+                console.log("# ".concat(item.name));
+                console.log(completeSnippet);
+                console.log();
+            }
+            else {
+                console.log(completeSnippet);
+            }
         });
     }
     else if (isItemGroup(item)) {
         item.items.all().forEach(printSnippet);
     }
 }
-var environmentVariables = new postman_collection_1.VariableList(new postman_collection_1.Property({ name: 'environmentVariables' }), []);
-if (program['envvars']) {
-    var environment = JSON.parse((0, fs_1.readFileSync)(program['envvars']).toString());
+var environmentVariables = new postman_collection_1.VariableList(new postman_collection_1.Property({ name: "environmentVariables" }), []);
+if (program["envvars"]) {
+    var environment = JSON.parse((0, fs_1.readFileSync)(program["envvars"]).toString());
     debugPrint(environment);
-    environment['values'].forEach(function (v) {
+    environment["values"].forEach(function (v) {
         environmentVariables.append(new postman_collection_1.Variable(v));
     });
 }
-var lvp = program['language_variant'];
+var lvp = program["language_variant"];
 debugPrint(environmentVariables);
 collection.items.all().forEach(printSnippet);

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ program
     .option("-e,--envvars <path>", "Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection")
     .option("-d, --debug", "Output additional debugging info")
     .option("--short", "Use short format for curl commands")
-    .option("--names", "Add request names as headers/comments in curl commands output");
+    .option("--names", "Add request names as comments in curl commands output");
 program.parse(process.argv);
 function debugPrint(message) {
     if (program.debug) {

--- a/main.ts
+++ b/main.ts
@@ -4,100 +4,103 @@ import {
   ItemGroup,
   VariableList,
   Property,
-  Variable
-} from 'postman-collection';
-const codegen = require('postman-code-generators');
+  Variable,
+} from "postman-collection";
+const codegen = require("postman-code-generators");
 
-import { readFileSync } from 'fs';
+import { readFileSync } from "fs";
 
-import * as commander from 'commander';
+import * as commander from "commander";
 
 const languageVariantPairs = [
-  'C#,RestSharp',
-  'Dart,http',
-  'cURL,cURL',
-  'Go,Native',
-  'HTTP,HTTP',
-  'Java,OkHttp',
-  'Java,Unirest',
-  'JavaScript,Fetch',
-  'JavaScript,jQuery',
-  'JavaScript,XHR',
-  'NodeJs,Native',
-  'NodeJs,Request',
-  'NodeJs,Unirest',
-  'Objective-C,NSURLSession',
-  'OCaml,Cohttp',
-  'PHP,cURL',
-  'PHP,pecl_http',
-  'PHP,HTTP_Request2',
-  'PowerShell,RestMethod',
-  'Python,http.client',
-  'Python,Requests',
-  'Ruby,Net:HTTP',
-  'Shell,Httpie',
-  'Shell,wget',
-  'Swift,URLSession'
-].map(v => v.toLowerCase());
+  "C#,RestSharp",
+  "Dart,http",
+  "cURL,cURL",
+  "Go,Native",
+  "HTTP,HTTP",
+  "Java,OkHttp",
+  "Java,Unirest",
+  "JavaScript,Fetch",
+  "JavaScript,jQuery",
+  "JavaScript,XHR",
+  "NodeJs,Native",
+  "NodeJs,Request",
+  "NodeJs,Unirest",
+  "Objective-C,NSURLSession",
+  "OCaml,Cohttp",
+  "PHP,cURL",
+  "PHP,pecl_http",
+  "PHP,HTTP_Request2",
+  "PowerShell,RestMethod",
+  "Python,http.client",
+  "Python,Requests",
+  "Ruby,Net:HTTP",
+  "Shell,Httpie",
+  "Shell,wget",
+  "Swift,URLSession",
+].map((v) => v.toLowerCase());
 
 function parseTuple(
   value: string,
-  dummy: string
+  dummy: string,
 ): { language: string; variant: string } {
   const v = value.trim().toLowerCase();
   if (!languageVariantPairs.includes(v)) {
     throw `Not a valid <langauge,variant> pair.Try one of:\n${languageVariantPairs.join(
-      '\n'
+      "\n",
     )}\n`;
   }
 
-  const tuple = v.split(',');
+  const tuple = v.split(",");
 
   console.assert(tuple.length === 2);
   return { language: tuple[0], variant: tuple[1] };
 }
 
-const program = new commander.Command('generate');
-program.version('0.2');
+const program = new commander.Command("generate");
+program.version("0.2");
 
 program
   .requiredOption(
-    '-c, --collection <path>',
-    'Path to the Postman 2.1 Collection JSON'
+    "-c, --collection <path>",
+    "Path to the Postman 2.1 Collection JSON",
   )
   .option(
-    '-l,--language_variant <tuple>',
-    'Language,Variant pair to output',
+    "-l,--language_variant <tuple>",
+    "Language,Variant pair to output",
     parseTuple,
-    { language: 'curl', variant: 'curl' }
+    { language: "curl", variant: "curl" },
   )
   .option(
-    '-e,--envvars <path>',
-    `Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection`
+    "-e,--envvars <path>",
+    `Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection`,
   )
-  .option('-d, --debug', 'Output additional debugging info');
+  .option("-d, --debug", "Output additional debugging info")
+  .option("--short", "Use short format for commands")
+  .option("--names", "Output request names with hashtag and newline");
 
 program.parse(process.argv);
 
 function debugPrint(message: any) {
   if (program.debug) {
-    console.log('DEBUG:', message);
+    console.log("DEBUG:", message);
   }
 }
 
 debugPrint(program.opts());
 
-const collectionPath: string = program['collection'];
+const collectionPath: string = program["collection"];
 
 const collection = new Collection(
-  JSON.parse(readFileSync(collectionPath).toString())
+  JSON.parse(readFileSync(collectionPath).toString()),
 );
 
 debugPrint(collection);
 
 const options = {
   trimRequestBody: true,
-  followRedirect: true
+  followRedirect: true,
+  longFormat: !program["short"],
 };
 
 function isItem(itemG: Item | ItemGroup<Item>): itemG is Item {
@@ -110,46 +113,56 @@ function isItemGroup(itemG: Item | ItemGroup<Item>): itemG is ItemGroup<Item> {
 
 function printSnippet(item: Item | ItemGroup<Item>) {
   if (isItem(item)) {
-    codegen.convert(lvp.language, lvp.variant, item.request, options, function(
-      error: any,
-      snippet: any
-    ) {
-      if (error) {
-        console.error(
-          'Error trying to generate code for request:',
-          item.request,
-          error
+    codegen.convert(
+      lvp.language,
+      lvp.variant,
+      item.request,
+      options,
+      function (error: any, snippet: any) {
+        if (error) {
+          console.error(
+            "Error trying to generate code for request:",
+            item.request,
+            error,
+          );
+        }
+        const completeSnippet = collection.variables.replace(
+          snippet,
+          environmentVariables,
         );
-      }
-      const completeSnippet = collection.variables.replace(
-        snippet,
-        environmentVariables
-      );
-      const re = /(?:\{\{(.+?)\}\})/g;
-      const matches = re.exec(completeSnippet);
-      if (matches && matches.length > 0) {
-        matches.forEach(m => console.warn(`${m} : Variable not provided`));
-      }
-      console.log(completeSnippet);
-    });
+        const re = /(?:\{\{(.+?)\}\})/g;
+        const matches = re.exec(completeSnippet);
+        if (matches && matches.length > 0) {
+          matches.forEach((m) => console.warn(`${m} : Variable not provided`));
+        }
+        // add request name as header if --names is set
+        if (program["names"]) {
+          console.log(`# ${item.name}`);
+          console.log(completeSnippet);
+          console.log();
+        } else {
+          console.log(completeSnippet);
+        }
+      },
+    );
   } else if (isItemGroup(item)) {
     item.items.all().forEach(printSnippet);
   }
 }
 
 const environmentVariables = new VariableList(
-  new Property({ name: 'environmentVariables' }),
-  []
+  new Property({ name: "environmentVariables" }),
+  [],
 );
-if (program['envvars']) {
-  const environment = JSON.parse(readFileSync(program['envvars']).toString());
+if (program["envvars"]) {
+  const environment = JSON.parse(readFileSync(program["envvars"]).toString());
   debugPrint(environment);
-  environment['values'].forEach((v: { value: string; key: string }) => {
+  environment["values"].forEach((v: { value: string; key: string }) => {
     environmentVariables.append(new Variable(v));
   });
 }
 
-const lvp: { language: string; variant: string } = program['language_variant'];
+const lvp: { language: string; variant: string } = program["language_variant"];
 debugPrint(environmentVariables);
 
 collection.items.all().forEach(printSnippet);

--- a/main.ts
+++ b/main.ts
@@ -76,8 +76,12 @@ program
     `Path to environment variables exported from Postman. NOTE: Environment variables will not override variables provided in collection`,
   )
   .option("-d, --debug", "Output additional debugging info")
-  .option("--short", "Use short format for commands")
-  .option("--names", "Output request names with hashtag and newline");
+
+  .option("--short", "Use short format for curl commands")
+  .option(
+    "--names",
+    "Add request names as headers/comments in curl commands output",
+  );
 
 program.parse(process.argv);
 

--- a/main.ts
+++ b/main.ts
@@ -101,10 +101,12 @@ const collection = new Collection(
 
 debugPrint(collection);
 
+const lvp: { language: string; variant: string } = program["language_variant"];
+
 const options = {
   trimRequestBody: true,
   followRedirect: true,
-  longFormat: !program["short"],
+  longFormat: !(program["short"] && lvp.language === "curl" && lvp.variant === "curl"),
 };
 
 function isItem(itemG: Item | ItemGroup<Item>): itemG is Item {
@@ -139,11 +141,15 @@ function printSnippet(item: Item | ItemGroup<Item>) {
         if (matches && matches.length > 0) {
           matches.forEach((m) => console.warn(`${m} : Variable not provided`));
         }
-        // add request name as header if --names is set
-        if (program["names"]) {
-          console.log(`# ${item.name}`);
-          console.log(completeSnippet);
-          console.log();
+        // output request names as comments for curl if --names flag is set
+        if (lvp.language === "curl" && lvp.variant === "curl") {
+          if (program["names"]) {
+            console.log(`# ${item.name}`);
+            console.log(completeSnippet);
+            console.log();
+          } else {
+            console.log(completeSnippet);
+          }
         } else {
           console.log(completeSnippet);
         }
@@ -166,7 +172,7 @@ if (program["envvars"]) {
   });
 }
 
-const lvp: { language: string; variant: string } = program["language_variant"];
+
 debugPrint(environmentVariables);
 
 collection.items.all().forEach(printSnippet);

--- a/main.ts
+++ b/main.ts
@@ -80,7 +80,7 @@ program
   .option("--short", "Use short format for curl commands")
   .option(
     "--names",
-    "Add request names as headers/comments in curl commands output",
+    "Add request names as comments in curl commands output",
   );
 
 program.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,20 @@
         "postman-sdk": "^1.3.7"
       },
       "devDependencies": {
-        "@types/node": "^13.9.0",
-        "@types/postman-collection": "^3.5.7"
+        "@types/node": "^22.13.5",
+        "@types/postman-collection": "^3.5.7",
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
-      "dev": true
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
     },
     "node_modules/@types/postman-collection": {
       "version": "3.5.7",
@@ -1181,6 +1186,27 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1250,10 +1276,13 @@
   },
   "dependencies": {
     "@types/node": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
-      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ==",
-      "dev": true
+      "version": "22.13.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
+      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.20.0"
+      }
     },
     "@types/postman-collection": {
       "version": "3.5.7",
@@ -1419,9 +1448,9 @@
       }
     },
     "decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1993,9 +2022,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
       "version": "6.11.1",
@@ -2183,6 +2212,18 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "postman-sdk": "^1.3.7"
   },
   "devDependencies": {
-    "@types/node": "^13.9.0",
-    "@types/postman-collection": "^3.5.7"
+    "@types/node": "^22.13.5",
+    "@types/postman-collection": "^3.5.7",
+    "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
`--names` flag will output request names as headers/comments in the curl output
`--short` flag will set option `longFormat` to `false` to use shorthand arguments in curl command